### PR TITLE
File system cache and return files

### DIFF
--- a/Documentation/FileSystem.txt
+++ b/Documentation/FileSystem.txt
@@ -8,11 +8,6 @@
                          │___╱                                                                         
 ---------------------------------------------------------------------------------------
 
-Still a work in progress, I will soon add a method to get the file contents in the cache
-or by reading from the file.
-This method will not be called upon construction of the object to not waste time on getting
-a file that shouldnt be accessed for whatever reason.
-
 FILESSYSTEM USAGE:
 
 - FileSystem::FileSystem(SafePath path)  
@@ -21,6 +16,11 @@ FILESSYSTEM USAGE:
   - Sets file size, last modified time, MIME type, and file permissions (readable, writable, executable)  
   - Determines if the path is a directory  
   - If file does not exist, sets defaults: size=0, lastModified=0, mimeType=NO_FILE, isDirectory=false, readable=false, writable=false, executable=false  
+
+- getFileContents()
+  Returns the contents of the file. The string is not stored at FileSystem construction to not read files for nothing.
+  Return type: const std::string  
+  Usage: fileSystem.getFileContents()
 
 - getPath()  
   Returns the SafePath object used to create the FileSystem  

--- a/Documentation/SafePath.txt
+++ b/Documentation/SafePath.txt
@@ -21,6 +21,11 @@ SAFEPATH USAGE
   Return type: std::string  
   Usage: sp.getFullPath()
 
+- getLocation()
+  Returns the location to which the path belongs
+  Return type: std::string  
+  Usage: sp.getLocation()
+
 - getRequestedPath() (!unsafe!)
   Returns the raw requested path  
   Return type: std::string  

--- a/Documentation/ServerConfig.txt
+++ b/Documentation/ServerConfig.txt
@@ -49,16 +49,19 @@ will access location struct filled with default settings.
 
 Fields in LocationConfig:
 
-- g_config[locationPath].path                  : location path (std::string)
-- g_config[locationPath].getAllowed            : GET allowed (bool)
-- g_config[locationPath].postAllowed           : POST allowed (bool)
-- g_config[locationPath].deleteAllowed         : DELETE allowed (bool)
-- g_config[locationPath].root                  : location root path (std::string)
-- g_config[locationPath].index                 : default index file (std::string)
-- g_config[locationPath].autoindex             : directory listing enabled (bool)
-- g_config[locationPath].redirect_enabled      : redirection enabled (bool)
-- g_config[locationPath].redirect_url          : redirection target (std::string)
-- g_config[locationPath].redirect_code         : HTTP status code for redirection (int)
-- g_config[locationPath].upload_enabled        : uploads enabled (bool)
-- g_config[locationPath].upload_store          : upload destination folder (std::string)
-- g_config[locationPath].cgi_pass              : map of file extensions to CGI executables (std::map<std::string, std::string>)
+"arg" can be either a FileSystem object, a SafePath object, or a string.
+I made a []operator that takes a string just in case but best not use it unless you're sure the path is ok.
+
+- g_config[arg].path                  : location (std::string)
+- g_config[arg].getAllowed            : GET allowed (bool)
+- g_config[arg].postAllowed           : POST allowed (bool)
+- g_config[arg].deleteAllowed         : DELETE allowed (bool)
+- g_config[arg].root                  : location root path (std::string)
+- g_config[arg].index                 : default index file (std::string)
+- g_config[arg].autoindex             : directory listing enabled (bool)
+- g_config[arg].redirect_enabled      : redirection enabled (bool)
+- g_config[arg].redirect_url          : redirection target (std::string)
+- g_config[arg].redirect_code         : HTTP status code for redirection (int)
+- g_config[arg].upload_enabled        : uploads enabled (bool)
+- g_config[arg].upload_store          : upload destination folder (std::string)
+- g_config[arg].cgi_pass              : map of file extensions to CGI executables (std::map<std::string, std::string>)

--- a/configFiles/webserv.conf
+++ b/configFiles/webserv.conf
@@ -6,8 +6,8 @@ server_name webserv
 
 # Last root directive overwrites the previous ones. You can add your machine's path
 # and move the lines around as needed
-root /Users/clement/repojump/clement2150005/web-server/www # Clément's Mac
 root /home/clement/repojump/clement2150005/web-server/www # Clément's Linux
+root /Users/clement/repojump/clement2150005/web-server/www # Clément's Mac
 
 # Default error pages
 error_page 400 /errors/400.html
@@ -32,14 +32,16 @@ location / {
 # Static files (CSS, JS, images, PDF, etc.)
 location /mimeType {
     methods GET
-    root /var/www/mimeTypeDetectionTestFiles
+    root /home/clement/repojump/clement2150005/web-server/www/mimeTypeDetectionTestFiles # Clément's Linux
+    root /Users/clement/repojump/clement2150005/web-server/www/mimeTypeDetectionTestFiles # Clément's Mac
     autoindex on
 }
 
 # CGI scripts
 location /cgi {
     methods GET POST
-    root /var/www/cgi-bin
+    root /home/clement/repojump/clement2150005/web-server/www/cgi-bin # Clément's Linux
+    root /Users/clement/repojump/clement2150005/web-server/www/cgi-bin # Clément's Mac
     cgi .php /usr/bin/php-cgi
     cgi .py /usr/bin/python
     autoindex off
@@ -49,21 +51,16 @@ location /cgi {
 location /redirect/old.html {
     methods GET
     return 301 /redirection/new.html
-    root /var/www/redirection
+    root /home/clement/repojump/clement2150005/web-server/www/redirection/old.html # Clément's Linux
+    root /Users/clement/repojump/clement2150005/web-server/www/redirection/old.html # Clément's Mac
 }
 
 # Upload endpoint
 location /upload {
     methods POST
     root /var/www
-    upload_enabled on
-    upload_path /var/www/upload
-    autoindex off
-}
-
-location /test {
-    methods POST
-    root /var/etc
+    root /home/clement/repojump/clement2150005/web-server/www/upload # Clément's Linux
+    root /Users/clement/repojump/clement2150005/web-server/www/upload # Clément's Mac
     upload_enabled on
     upload_path /var/www/upload
     autoindex off

--- a/configFiles/webserv.conf
+++ b/configFiles/webserv.conf
@@ -3,7 +3,11 @@ listen 127.0.0.1:8080
 listen 0.0.0.0:80
 
 server_name webserv
-root /var/www
+
+# Last root directive overwrites the previous ones. You can add your machine's path
+# and move the lines around as needed
+root /Users/clement/repojump/clement2150005/web-server/www # Clément's Mac
+root /home/clement/repojump/clement2150005/web-server/www # Clément's Linux
 
 # Default error pages
 error_page 400 /errors/400.html
@@ -26,14 +30,14 @@ location / {
 }
 
 # Static files (CSS, JS, images, PDF, etc.)
-location /mimeTypeDetectionTestFiles {
+location /mimeType {
     methods GET
-    root /var/www/
+    root /var/www/mimeTypeDetectionTestFiles
     autoindex on
 }
 
 # CGI scripts
-location /cgi-bin {
+location /cgi {
     methods GET POST
     root /var/www/cgi-bin
     cgi .php /usr/bin/php-cgi
@@ -42,16 +46,26 @@ location /cgi-bin {
 }
 
 # Redirection example
-location /redirection/old.html {
+location /redirect/old.html {
     methods GET
     return 301 /redirection/new.html
+    root /var/www/redirection
 }
 
 # Upload endpoint
 location /upload {
     methods POST
-    root /var/www/upload
+    root /var/www
     upload_enabled on
     upload_path /var/www/upload
     autoindex off
 }
+
+location /test {
+    methods POST
+    root /var/etc
+    upload_enabled on
+    upload_path /var/www/upload
+    autoindex off
+}
+

--- a/include/linuxOrMac.hpp
+++ b/include/linuxOrMac.hpp
@@ -1,6 +1,0 @@
-#pragma once
-#if defined(__linux__)
-	#define LINUX 1
-#else
-	#define LINUX 0
-#endif

--- a/include/linuxOrMac.hpp
+++ b/include/linuxOrMac.hpp
@@ -1,0 +1,6 @@
+#pragma once
+#if defined(__linux__)
+	#define LINUX 1
+#else
+	#define LINUX 0
+#endif

--- a/src/configFileParser/ServerConfig.hpp
+++ b/src/configFileParser/ServerConfig.hpp
@@ -1,12 +1,13 @@
 #pragma once
 
+#include "../src/fileSystem/FileSystem.hpp"
 #include <iostream>
 #include <vector>
 #include <map>
 
 struct LocationConfig
 {
-	std::string path;
+	std::string location;
 
 	bool getAllowed;
 	bool postAllowed;
@@ -38,7 +39,10 @@ public:
 	const std::map<std::string, LocationConfig>& getLocations() const;
 	const std::string& getServerName() const;
 
-	LocationConfig operator[](const std::string& path) const;
+	LocationConfig operator[](const SafePath& safePath) const;
+	LocationConfig operator[](const std::string& location) const;
+	LocationConfig operator[](const FileSystem& file) const;
+	LocationConfig getLocationConfigOrDefault(std::map<std::string, LocationConfig>::const_iterator it) const;
 
 private:
 	std::string root;
@@ -90,3 +94,6 @@ bool isValidRedirectTarget(const std::string& target);
 void directiveError(std::string dir);
 void argumentError(std::string arg, std::string dir);
 void missingArgument(std::string dir);
+
+std::ostream& operator<<(std::ostream& os, const LocationConfig& loc);
+std::ostream& operator<<(std::ostream& os, const ServerConfig& server);

--- a/src/errorHandling/ErrorWarning.cpp
+++ b/src/errorHandling/ErrorWarning.cpp
@@ -1,9 +1,10 @@
 #include "ErrorWarning.hpp"
+#include <stdexcept>
 
 void error(const std::string& msg, const std::string& origin)
 {
-	std::cerr << "\033[1m\033[31mError: \033[0m\033[1m" << origin << "\033[0m: " << msg << std::endl;
-	std::exit(1);
+	std::string formatted = "\033[1m\033[31mError: \033[0m\033[1m" + origin + "\033[0m: " + msg;
+	throw std::runtime_error(formatted);
 }
 
 void warning(const std::string& msg, const std::string& origin)

--- a/src/fileSystem/File system Static html.md
+++ b/src/fileSystem/File system Static html.md
@@ -1,0 +1,188 @@
+# File system / Static html
+
+this should be pretty easy…
+
+### **Primary Responsibilities**
+
+Serve static files safely and efficiently, handle file operations, and manage server configuration.
+
+### **Key Components to Build**
+
+### **1. Safe File Server**
+
+```cpp
+class FileServer {
+    std::string document_root;
+
+public:
+    FileServer(const std::string& root);
+    HttpResponse serve_file(const std::string& requested_path);
+    bool file_exists(const std::string& path);
+    bool is_safe_path(const std::string& path);
+
+private:
+    std::string resolve_path(const std::string& requested_path);
+    std::string read_file_content(const std::string& full_path);
+};
+
+```
+
+**Tasks:**
+
+- Resolve requested paths to actual file paths
+- Prevent directory traversal attacks (`../../../etc/passwd`)
+- Handle index files (serve `index.html` for `/` requests)
+- Check file permissions and existence
+- Read file content efficiently
+
+### **2. Directory Listing (Optional Feature)**
+
+```cpp
+class DirectoryHandler {
+public:
+    HttpResponse generate_directory_listing(const std::string& dir_path,
+                                          const std::string& url_path);
+
+private:
+    std::string generate_html_listing(const std::vector<FileInfo>& files);
+};
+
+```
+
+**Tasks:**
+
+- Generate HTML directory listings when no index file exists
+- Sort files/directories appropriately
+- Show file sizes and modification dates
+- Make listings clickable/navigable
+
+### **3. File Information & Caching**
+
+```cpp
+struct FileInfo {
+    std::string full_path;
+    size_t size;
+    time_t last_modified;
+    std::string mime_type;
+    bool exists;
+    bool is_directory;
+};
+
+class FileCache {
+    std::map<std::string, CachedFile> cache;
+    size_t max_cache_size;
+
+public:
+    FileInfo get_file_info(const std::string& path);
+    std::string get_cached_content(const std::string& path);
+    void cache_file(const std::string& path, const std::string& content);
+};
+
+```
+
+**Tasks:**
+
+- Get file metadata using `stat()`
+- Cache frequently accessed files in memory
+- Handle cache invalidation (check modification time)
+- Implement cache size limits
+
+### **4. Configuration Manager**
+
+```cpp
+class ServerConfig {
+public:
+    int port;
+    std::string document_root;
+    std::vector<std::string> index_files;
+    size_t max_file_size;
+    bool enable_directory_listing;
+
+    bool load_config(const std::string& config_file);
+
+private:
+    void parse_config_line(const std::string& line);
+};
+
+```
+
+**Tasks:**
+
+- Parse configuration file (simple key=value format)
+- Set default values for all settings
+- Validate configuration values
+- Handle missing config file gracefully
+
+### **5. Error Page Generator**
+
+```cpp
+class ErrorPages {
+public:
+    std::string generate_404_page(const std::string& requested_path);
+    std::string generate_500_page();
+    std::string generate_403_page();
+
+private:
+    std::string load_custom_error_page(int status_code);
+    std::string generate_default_error_page(int status_code, const std::string& message);
+};
+
+```
+
+**Tasks:**
+
+- Generate HTML error pages
+- Support custom error page files (404.html, 500.html)
+- Create reasonable default error pages
+- Include useful error information
+
+### **Security Considerations:**
+
+```cpp
+class PathValidator {
+public:
+    static bool is_safe_path(const std::string& path);
+    static std::string normalize_path(const std::string& path);
+
+private:
+    static bool contains_traversal(const std::string& path);
+    static std::string resolve_symlinks(const std::string& path);
+};
+
+```
+
+**Tasks:**
+
+- Block `../` directory traversal attempts
+- Normalize paths (`/./path` → `/path`)
+- Handle symbolic links safely
+- Restrict access to document root only
+
+### **Key Functions You'll Use:**
+
+`open`, `read`, `close`, `stat`, `access`, `opendir`, `readdir`, `chdir` (to validate paths)
+
+### **File Operations to Handle:**
+
+- Text files (HTML, CSS, JavaScript, JSON)
+- Binary files (images, videos, executables)
+- Large files (streaming vs loading into memory)
+- Non-existent files (404 handling)
+- Permission denied (403 handling)
+
+### **Testing Strategy:**
+
+- Test various file types and extensions
+- Try directory traversal attacks: `GET /../../../etc/passwd`
+- Test large files and binary files
+- Verify MIME types are set correctly
+- Test with missing files and directories
+
+### **Deliverables:**
+
+1. Safe file serving with security checks
+2. Support for all common web file types
+3. Configuration system for server settings
+4. Error page generation
+5. Optional: File caching for performance
+6. Optional: Directory listing generation

--- a/src/fileSystem/FileSystem.cpp
+++ b/src/fileSystem/FileSystem.cpp
@@ -1,5 +1,5 @@
 #include "../src/fileSystem/FileSystem.hpp"
-#include "../src/fileSystem/SafePath.hpp"
+#include "../src/errorHandling/ErrorWarning.hpp"
 
 FileSystem::FileSystem(SafePath path) : fullPath(path)
 {
@@ -70,6 +70,18 @@ e_mimeType FileSystem::detectMimeType(const SafePath& safePath)
 		return IMAGE_SVG;
 
 	return APPLICATION_OCTET_STREAM;
+}
+
+const std::string FileSystem::getFileContents()
+{
+	std::ifstream file(fullPath.getFullPath().c_str(), std::ios::binary);
+
+	if (!file)
+		error("Couldn't open file '" + fullPath.getFullPath() + "'", "File system");
+
+	std::ostringstream oss;
+	oss << file.rdbuf();
+	return oss.str();
 }
 
 const SafePath& FileSystem::getPath() const { return fullPath; }

--- a/src/fileSystem/FileSystem.cpp
+++ b/src/fileSystem/FileSystem.cpp
@@ -1,4 +1,5 @@
 #include "../src/fileSystem/FileSystem.hpp"
+#include "../include/globals.hpp"
 #include "../src/errorHandling/ErrorWarning.hpp"
 
 FileSystem::FileSystem(SafePath path) : fullPath(path)
@@ -93,3 +94,19 @@ bool FileSystem::directory() const { return isDirectory; }
 bool FileSystem::readable() const { return isReadable; }
 bool FileSystem::writable() const { return isWritable; }
 bool FileSystem::executable() const { return isExecutable; }
+
+std::ostream& operator<<(std::ostream& os, const FileSystem& file)
+{
+	os << "Path: " << file.getPath().getFullPath() << std::endl;
+	os << "Requested path: " << file.getPath().getRequestedPath() << std::endl;
+	os << "Size: " << file.getSize() << " bytes\n";
+	os << "Last modified: " << file.getLastModified() << std::endl;
+	os << "MIME type: " << file.getMimeType() << std::endl;
+	os << "Exists: " << file.exists() << std::endl;
+	os << "Directory: " << file.directory() << std::endl;
+	os << "Readable: " << file.readable() << std::endl;
+	os << "Writable: " << file.writable() << std::endl;
+	os << "Executable: " << file.executable() << std::endl << std::endl;
+	os << g_config[file.getPath()] << std::endl;
+	return os;
+}

--- a/src/fileSystem/FileSystem.hpp
+++ b/src/fileSystem/FileSystem.hpp
@@ -39,3 +39,5 @@ public:
 	bool writable() const;
 	bool executable() const;
 };
+
+std::ostream& operator<<(std::ostream& os, const FileSystem& file);

--- a/src/fileSystem/FileSystem.hpp
+++ b/src/fileSystem/FileSystem.hpp
@@ -4,28 +4,31 @@
 #include <algorithm>
 #include <sys/stat.h>
 #include <unistd.h>
+#include <fstream>
+#include <sstream>
 #include <stdexcept>
-#include "SafePath.hpp"
+#include "../src/fileSystem/SafePath.hpp"
 #include "enums.hpp"
 
 class FileSystem
 {
 private:
-	SafePath fullPath;        // "/var/www/html/images/photo.jpg"
-	size_t size;                 // 1024768 (bytes)
-	time_t lastModified;        // 1640995200 (Unix timestamp)
+	SafePath fullPath;
+	size_t size;
+	time_t lastModified;
 	e_mimeType mimeType;
-	bool isExists;                 // true/false
-	bool isDirectory;           // true/false
-	bool isReadable;            // true/false
-	bool isWritable;            // true/false
-	bool isExecutable;            // true/false
+	bool isExists;
+	bool isDirectory;
+	bool isReadable;
+	bool isWritable;
+	bool isExecutable;
 
 	e_mimeType detectMimeType(const SafePath& safePath);
 
 public:
 	FileSystem(SafePath path);
 
+	const std::string getFileContents();
 	const SafePath& getPath() const;
 	size_t getSize() const;
 	time_t getLastModified() const;

--- a/src/fileSystem/Notes.md
+++ b/src/fileSystem/Notes.md
@@ -1,3 +1,0 @@
-ccolin
-
-This is where all the file system managment classes and functions will go

--- a/src/fileSystem/SafePath.cpp
+++ b/src/fileSystem/SafePath.cpp
@@ -1,20 +1,58 @@
 #include "../src/fileSystem/SafePath.hpp"
 #include "../include/globals.hpp"
+#include "../src/errorHandling/ErrorWarning.hpp"
 
 
 SafePath::SafePath(const std::string& path)
 	: requestedPath(path)
 {
+	if (path[0] != '/')
+		error("Invalid path '" + requestedPath + "' must start with /", "SafePath");
+
 	if (path.find("..") != std::string::npos)
-		throw std::runtime_error("Unsafe path");
+		error("Unsafe path '" + requestedPath + "'", "SafePath");
 
-	fullPath = g_config[path].root;
+	std::vector<std::string> splited = splitPath(path);
+	location = g_config["/" + splited[0]].location;
+	std::string root = g_config[location].root;
 
-	if (!requestedPath.empty() && requestedPath[0] != '/')
-		fullPath += '/';
-
-	fullPath += requestedPath;
+	if (location == "/")
+		fullPath = root + requestedPath;
+	else
+	{
+		std::string remainder = requestedPath.substr(location.size());
+		fullPath = root + remainder;
+	}
 }
+
+std::vector<std::string> SafePath::splitPath(const std::string &path)
+{
+	std::vector<std::string> parts;
+	std::string current;
+
+	for (size_t i = 0; i < path.size(); ++i)
+	{
+		if (path[i] == '/')
+		{
+			if (!current.empty())
+			{
+				parts.push_back(current);
+				current.clear();
+			}
+		}
+		else
+			current += path[i];
+	}
+
+	if (!current.empty())
+		parts.push_back(current);
+
+	return parts;
+}
+
 std::string SafePath::getRequestedPath() const { return requestedPath; }
 std::string SafePath::getFullPath() const { return fullPath; }
+std::string SafePath::getLocation() const { return location; }
 SafePath::operator std::string() const { return fullPath; }
+
+std::ostream& operator <<(std::ostream& os, const SafePath& sp) { return os << std::string(sp); }

--- a/src/fileSystem/SafePath.cpp
+++ b/src/fileSystem/SafePath.cpp
@@ -55,4 +55,4 @@ std::string SafePath::getFullPath() const { return fullPath; }
 std::string SafePath::getLocation() const { return location; }
 SafePath::operator std::string() const { return fullPath; }
 
-std::ostream& operator <<(std::ostream& os, const SafePath& sp) { return os << std::string(sp); }
+std::ostream& operator<<(std::ostream& os, const SafePath& sp) { return os << std::string(sp); }

--- a/src/fileSystem/SafePath.hpp
+++ b/src/fileSystem/SafePath.hpp
@@ -21,4 +21,4 @@ public:
 	operator std::string() const;
 };
 
-std::ostream& operator <<(std::ostream& os, const SafePath& sp);
+std::ostream& operator<<(std::ostream& os, const SafePath& sp);

--- a/src/fileSystem/SafePath.hpp
+++ b/src/fileSystem/SafePath.hpp
@@ -1,20 +1,24 @@
 #pragma once
 
-#include <string>
+#include <iostream>
 #include <stdexcept>
-
-#include "../src/configFileParser/ServerConfig.hpp"
+#include <vector>
 
 class SafePath
 {
 private:
 	std::string requestedPath;
 	std::string fullPath;
+	std::string location;
 
 public:
 	SafePath(const std::string& path);
 
+	std::vector<std::string> splitPath(const std::string &path);
 	std::string getRequestedPath() const;
 	std::string getFullPath() const;
+	std::string getLocation() const;
 	operator std::string() const;
 };
+
+std::ostream& operator <<(std::ostream& os, const SafePath& sp);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,10 +7,13 @@
 #include "http/httpTester.hpp"
 #include "../src/tests/tests.hpp"
 
+#include "../include/linuxOrMac.hpp"
+
 ServerConfig g_config;
 
 int main(int argc, char *argv[])
 {
+	std::cout << LINUX << std::endl;
 	try {g_config.initServerConfig(argc, argv);}
 	catch (const std::runtime_error& e) {std::cerr << e.what() << std::endl; return 1;} 
 	printConfig();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,22 +2,33 @@
 #include "../include/enums.hpp"
 #include "../include/globals.hpp"
 #include "http/HttpRequest/HttpRequest.hpp"
+#include "fileSystem/SafePath.hpp"
 #include "http/HttpResponse/HttpResponse.hpp"
 
 #include "http/httpTester.hpp"
 #include "../src/tests/tests.hpp"
 
-#include "../include/linuxOrMac.hpp"
+#include "fileSystem/FileSystem.hpp" // just for tests
 
 ServerConfig g_config;
 
 int main(int argc, char *argv[])
 {
-	std::cout << LINUX << std::endl;
 	try {g_config.initServerConfig(argc, argv);}
 	catch (const std::runtime_error& e) {std::cerr << e.what() << std::endl; return 1;} 
-	printConfig();
-	
+
+	//tests
+	//{
+		// printConfig();
+		try 
+		{
+			FileSystem file(SafePath("/index.html"));
+			if (file.exists())
+				std::cout << file.getFileContents() << std::endl;
+		}
+		catch (const std::runtime_error& e) {std::cerr << e.what() << std::endl; return 1;} 
+	//}
+
 	std::cout << "Web Server Starting..." << std::endl;
 	//uncommnet to run tests
 	// std::http_tester();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,7 +22,8 @@ int main(int argc, char *argv[])
 		// printConfig();
 		try 
 		{
-			FileSystem file(SafePath("/index.html"));
+			FileSystem file(SafePath("/mimeType/testFile.html"));
+			std::cout << file;
 			if (file.exists())
 				std::cout << file.getFileContents() << std::endl;
 		}

--- a/src/tests/configFileTest.cpp
+++ b/src/tests/configFileTest.cpp
@@ -1,7 +1,7 @@
 #include <vector>
 #include <iostream>
 #include <map>
-#include "../src/configFileParser/ServerConfig.hpp"
+#include "../src/fileSystem/SafePath.hpp"
 #include "../include/globals.hpp"
 
 void printConfig()
@@ -29,7 +29,7 @@ void printConfig()
 	for (std::map<std::string, LocationConfig>::const_iterator it = locations.begin(); it != locations.end(); ++it)
 	{
 		const LocationConfig& loc = it->second;
-		std::cout << "  Path: " << loc.path << std::endl;
+		std::cout << "  Location: " << loc.location << std::endl;
 		std::cout << "    Root: " << loc.root << std::endl;
 		std::cout << "    Index: " << loc.index << std::endl;
 		std::cout << "    Autoindex: " << (loc.autoindex ? "on" : "off") << std::endl;
@@ -52,8 +52,8 @@ void printConfig()
 	}
 
 	std::cout << "Accessing a location by name" << std::endl;
-	const LocationConfig& loc = g_config["/redirection/old.html"];
-	std::cout << "Path: " << loc.path << std::endl;
+	const LocationConfig& loc = g_config[SafePath("/cgi")];
+	std::cout << "Location: " << loc.location << std::endl;
 	std::cout << "  Root: " << loc.root << std::endl;
 	std::cout << "  Index: " << loc.index << std::endl;
 	std::cout << "  Autoindex: " << (loc.autoindex ? "on" : "off") << std::endl;
@@ -73,8 +73,8 @@ void printConfig()
 	}
 
 	std::cout << "Accessing a non existent location by name (should generate default configs)" << std::endl;
-	const LocationConfig& loc2 = g_config["/test"];
-	std::cout << "Path: " << loc2.path << std::endl;
+	const LocationConfig& loc2 = g_config[SafePath("/test")];
+	std::cout << "Location: " << loc2.location << std::endl;
 	std::cout << "  Root: " << loc2.root << std::endl;
 	std::cout << "  Index: " << loc2.index << std::endl;
 	std::cout << "  Autoindex: " << (loc2.autoindex ? "on" : "off") << std::endl;

--- a/www/mimeTypeDetectionTestFiles/testFile.html
+++ b/www/mimeTypeDetectionTestFiles/testFile.html
@@ -1,0 +1,27 @@
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Hello World</title>
+</head>
+<body>
+    <h1>Hello, World!</h1>
+
+    <ul>
+    <li><a href="/upload.html">Upload Page</a></li>
+    <li><a href="/errors/400.html">400 Bad Request</a></li>
+    <li><a href="/errors/403.html">403 Forbidden</a></li>
+    <li><a href="/errors/404.html">404 Not Found</a></li>
+    <li><a href="/errors/405.html">405 Method Not Allowed</a></li>
+    <li><a href="/errors/413.html">413 Payload Too Large</a></li>
+    <li><a href="/errors/500.html">500 Internal Server Error</a></li>
+    <li><a href="/redirection/old.html">Redirection Test (Old → New)</a></li>
+    <li><a href="/redirection/new.html">Redirection Target (New)</a></li>
+    <li><a href="/cgi-bin/test.php">PHP CGI Test</a></li>
+    <li><a href="/cgi-bin/test.py">Python CGI Test</a></li>
+    </ul>
+    
+</body>
+</html>


### PR DESCRIPTION
The root directives in location blocks are now working.
FileSystem can return the content of files.
I also added  some << operators to ServerConfig and FileSystem for easy debugging.
exemple:
`  std::cout << FileSystem(SafePath("path"))`

We can all use the same config file this way ⤵️
<img width="649" height="95" alt="Capture d’écran 2025-10-01 à 11 58 57" src="https://github.com/user-attachments/assets/20804333-e3dd-406e-adb1-cc62cb1ce11c" />
